### PR TITLE
use buildpack:set, config:set outdated

### DIFF
--- a/content/news/heroku-buildpack-pelican.rst
+++ b/content/news/heroku-buildpack-pelican.rst
@@ -18,8 +18,8 @@ buildpack takes care of this. Just push a git repository with the
 To enable the Heroku buildpack for existing sites, run:
 
 .. code-block:: bash
-
-    heroku config:set BUILDPACK_URL=https://github.com/getpelican/heroku-buildpack-pelican
+    
+    heroku buildpack:set https://github.com/getpelican/heroku-buildpack-pelican
 
 Alternatively, for those of you switching to Heroku, you can use the following
 command to create your Pelican site on Heroku.


### PR DESCRIPTION
Heroku asks that `heroku buildpack:set https://...` be used in place of `heroku config:set BUILDPACK_URL=https://...`.
https://devcenter.heroku.com/articles/buildpacks

Also, buildpack needs updating: getpelican/heroku-buildpack-pelican#7