### PR TITLE
fix typo in command `heroku buildpacks`

### DIFF
--- a/content/news/heroku-buildpack-pelican.rst
+++ b/content/news/heroku-buildpack-pelican.rst
@@ -19,7 +19,7 @@ To enable the Heroku buildpack for existing sites, run:
 
 .. code-block:: bash
     
-    heroku buildpack:set https://github.com/getpelican/heroku-buildpack-pelican
+    heroku buildpacks:set https://github.com/getpelican/heroku-buildpack-pelican
 
 Alternatively, for those of you switching to Heroku, you can use the following
 command to create your Pelican site on Heroku.


### PR DESCRIPTION
fix typo in command `heroku buildpacks`.
The command should be `heroku buildpacks:set` instead of `heroku buildpack:set`
